### PR TITLE
Add anxious task emotion with wellness prompts

### DIFF
--- a/MooDo/AI/MLTaskEngine.swift
+++ b/MooDo/AI/MLTaskEngine.swift
@@ -644,6 +644,7 @@ class MLTaskEngine: ObservableObject {
         case .focused: return 0.7
         case .creative: return 0.6
         case .stressful: return 0.8
+        case .anxious: return 0.8
         case .routine: return 0.4
         case .calming: return 0.3
         }

--- a/MooDo/Models.swift
+++ b/MooDo/Models.swift
@@ -92,6 +92,7 @@ enum TaskEmotion: String, CaseIterable, Codable {
     case creative = "creative"       // Creative work (design, brainstorming)
     case routine = "routine"         // Simple tasks (cut grass, organize)
     case stressful = "stressful"     // Demanding tasks (deadlines, presentations)
+    case anxious = "anxious"         // Anxious tasks needing wellness break
     
     var displayName: String {
         switch self {
@@ -101,6 +102,7 @@ enum TaskEmotion: String, CaseIterable, Codable {
         case .creative: return "Creative"
         case .routine: return "Routine"
         case .stressful: return "Stressful"
+        case .anxious: return "Anxious"
         }
     }
     
@@ -112,6 +114,7 @@ enum TaskEmotion: String, CaseIterable, Codable {
         case .creative: return "lightbulb"
         case .routine: return "repeat"
         case .stressful: return "exclamationmark.triangle"
+        case .anxious: return "questionmark.circle"
         }
     }
     
@@ -123,6 +126,7 @@ enum TaskEmotion: String, CaseIterable, Codable {
         case .creative: return Color(red: 0.56, green: 0.27, blue: 0.68) // creative-purple
         case .routine: return Color(red: 0.22, green: 0.69, blue: 0.42) // routine-green
         case .stressful: return Color(red: 0.91, green: 0.3, blue: 0.24) // stressful-red
+        case .anxious: return Color(red: 0.95, green: 0.86, blue: 0.07) // anxious-yellow
         }
     }
 }
@@ -314,6 +318,11 @@ class TaskManager: ObservableObject {
         
         // Immediate UI update (optimistic)
         tasks.append(newTask)
+
+        // Trigger wellness reminder for anxious tasks
+        if newTask.emotion == .anxious {
+            WellnessManager.shared.triggerMicroBreak()
+        }
         
         // Enhanced haptic feedback
         HapticManager.shared.taskAdded()
@@ -382,12 +391,17 @@ class TaskManager: ObservableObject {
     func updateTask(_ task: Task) {
         if let index = tasks.firstIndex(where: { $0.id == task.id }) {
             tasks[index] = task
-            
+
+            // Trigger wellness reminder for anxious tasks
+            if task.emotion == .anxious {
+                WellnessManager.shared.triggerMicroBreak()
+            }
+
             // Update EventKit reminder if it exists
             _Concurrency.Task {
                 await eventKitManager.updateReminder(for: task)
             }
-            
+
             debouncedSave()
         }
     }
@@ -1171,7 +1185,8 @@ class TaskScheduler: ObservableObject {
             .energizing: [.focused, .creative],
             .stressful: [.calming],
             .creative: [.energizing, .focused],
-            .routine: [.calming, .focused]
+            .routine: [.calming, .focused],
+            .anxious: [.calming]
         ]
         
         return compatibilityMap[emotion2]?.contains(emotion1) ?? false

--- a/MooDo/SmartFeatures.swift
+++ b/MooDo/SmartFeatures.swift
@@ -985,6 +985,13 @@ class SmartTaskSuggestions: ObservableObject {
                         emotion: .routine,
                         priority: .medium
                     ))
+                case .anxious:
+                    suggestions.append(TaskSuggestion(
+                        title: "Take a wellness break",
+                        description: "A short breathing or stretch break can ease anxiety",
+                        emotion: .calming,
+                        priority: .medium
+                    ))
                 case .stressful:
                     // Don't suggest stressful tasks based on history
                     break

--- a/MooDo/Utils/EmotionAnalyzer.swift
+++ b/MooDo/Utils/EmotionAnalyzer.swift
@@ -67,7 +67,7 @@ class EmotionAnalyzer {
             "pay", "bill", "invoice", "receipt", "form", "paperwork", "admin", "basic", "simple",
             "quick", "easy", "straightforward", "normal", "standard", "usual", "typical"
         ],
-        
+
         .stressful: [
             // Deadline pressure
             "deadline", "urgent", "asap", "rush", "hurry", "pressure", "stress", "crisis", "emergency",
@@ -77,6 +77,12 @@ class EmotionAnalyzer {
             "interview", "presentation", "meeting", "exam", "test", "evaluation", "review",
             // Anxiety-inducing
             "tax", "taxes", "legal", "doctor", "medical", "finance", "budget", "money", "debt"
+        ],
+
+        .anxious: [
+            // Anxiety-related terms
+            "anxious", "anxiety", "nervous", "worry", "worried", "uneasy", "fear", "scared",
+            "concern", "panic", "apprehensive"
         ]
     ]
     
@@ -97,7 +103,8 @@ class EmotionAnalyzer {
             .calming: 0,
             .focused: 0,
             .routine: 0,
-            .stressful: 0
+            .stressful: 0,
+            .anxious: 0
         ]
         
         // Analyze each word in the title
@@ -246,12 +253,18 @@ class EmotionAnalyzer {
                 return "Regular task detected"
             }
             return "Simple routine activity"
-            
+
         case .stressful:
             if lowercaseTitle.contains("deadline") || lowercaseTitle.contains("urgent") {
                 return "Time pressure detected"
             }
             return "Challenging task identified"
+
+        case .anxious:
+            if lowercaseTitle.contains("worry") || lowercaseTitle.contains("anxious") {
+                return "Anxiety-inducing task"
+            }
+            return "May trigger anxiety"
         }
     }
 }

--- a/MooDo/Utils/WellnessManager.swift
+++ b/MooDo/Utils/WellnessManager.swift
@@ -1,0 +1,24 @@
+import Foundation
+import UserNotifications
+
+class WellnessManager {
+    static let shared = WellnessManager()
+    private init() {}
+
+    private let actions = [
+        "Take 5 deep breaths",
+        "Stand up and stretch",
+        "Recall something you're grateful for"
+    ]
+
+    func triggerMicroBreak() {
+        let content = UNMutableNotificationContent()
+        content.title = "Wellness Break"
+        content.body = actions.randomElement() ?? "Take a short wellness break"
+        content.sound = .default
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+        UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+    }
+}

--- a/MooDo/Views/AddTaskViews.swift
+++ b/MooDo/Views/AddTaskViews.swift
@@ -596,6 +596,10 @@ struct AddTaskModalView: View {
         if content.contains("urgent") || content.contains("deadline") || content.contains("emergency") {
             return .stressful
         }
+
+        if content.contains("anxious") || content.contains("anxiety") || content.contains("nervous") || content.contains("worry") {
+            return .anxious
+        }
         
         if content.contains("creative") || content.contains("design") || content.contains("brainstorm") || content.contains("idea") {
             return .creative

--- a/MooDo/Views/Screens/MoodBasedTasksView.swift
+++ b/MooDo/Views/Screens/MoodBasedTasksView.swift
@@ -518,7 +518,11 @@ struct MoodBasedTasksView: View {
         if content.contains("energy") || content.contains("workout") || content.contains("exercise") || content.contains("project") || content.contains("taxes") {
             return .energizing
         }
-        
+
+        if content.contains("anxious") || content.contains("anxiety") || content.contains("nervous") || content.contains("worry") {
+            return .anxious
+        }
+
         if content.contains("deadline") || content.contains("urgent") || content.contains("important") || content.contains("presentation") || content.contains("stress") {
             return .stressful
         }

--- a/MooDo/Views/Tasks/TaskModals.swift
+++ b/MooDo/Views/Tasks/TaskModals.swift
@@ -188,7 +188,8 @@ struct EditTaskView: View {
                                 }
                                 
                                 Picker("Task Type", selection: $editedTask.emotion) {
-                                    ForEach(TaskEmotion.allCases, id: \.self) { emotion in
+                                    // Sorted to ensure new emotions like .anxious appear predictably
+                                    ForEach(TaskEmotion.allCases.sorted(by: { $0.displayName < $1.displayName }), id: \.self) { emotion in
                                         HStack {
                                             Image(systemName: emotion.icon)
                                                 .foregroundColor(emotion.color)


### PR DESCRIPTION
## Summary
- extend `TaskEmotion` with a new `.anxious` case and related display data
- surface the anxious option in emotion pickers and task analysis
- prompt wellness micro-breaks when anxious tasks are saved

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6896ed5071bc832e9b5a6e66fbdeba72