### PR TITLE
Add wellness actions and reminder notifications

### DIFF
--- a/MooDo/Models.swift
+++ b/MooDo/Models.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 import _Concurrency
+import UserNotifications
 
 // MARK: - Data Models
 
@@ -414,7 +415,14 @@ class TaskManager: ObservableObject {
         // Enhanced haptic feedback based on completion state
         if updatedTask.isCompleted {
             HapticManager.shared.taskCompleted()
-            
+
+            // Encourage wellness after long focus sessions
+            if updatedTask.emotion == .focused,
+               let minutes = updatedTask.estimatedTime,
+               minutes >= 45 {
+                scheduleWellnessReminder()
+            }
+
             // Cancel notification if task is completed early
             if let eventKitID = task.eventKitIdentifier {
                 eventKitManager.deleteReminder(eventKitIdentifier: eventKitID)
@@ -445,7 +453,25 @@ class TaskManager: ObservableObject {
             }
         }
     }
-    
+
+    private func scheduleWellnessReminder(after timeInterval: TimeInterval = 300) {
+        let content = UNMutableNotificationContent()
+        content.title = "Time for a break"
+        content.body = "Try a quick breathing exercise, stretch, or think of something you're grateful for."
+        content.sound = .default
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: false)
+        let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error {
+                print("⚠️ Failed to schedule wellness reminder: \(error.localizedDescription)")
+            } else {
+                print("🧘‍♀️ Scheduled wellness reminder")
+            }
+        }
+    }
+
     // MARK: - Completed Tasks Management
     
     private func archiveCompletedTask(_ task: Task) {

--- a/MooDo/Views/Components/WellnessActionsView.swift
+++ b/MooDo/Views/Components/WellnessActionsView.swift
@@ -1,0 +1,73 @@
+//
+//  WellnessActionsView.swift
+//  Moodo
+//
+//  Created by OpenAI ChatGPT on 15/8/2025.
+//
+
+import SwiftUI
+
+struct WellnessAction: Identifiable {
+    let id = UUID()
+    let title: String
+    let description: String
+}
+
+struct WellnessActionsView: View {
+    private let actions: [WellnessAction] = [
+        WellnessAction(
+            title: "Breathing Exercise",
+            description: "Breathe in for 4 seconds, hold for 4, and exhale for 4. Repeat a few times."
+        ),
+        WellnessAction(
+            title: "Quick Stretch",
+            description: "Stand up and stretch your arms overhead for 30 seconds."
+        ),
+        WellnessAction(
+            title: "Gratitude",
+            description: "Think of one thing you're grateful for right now."
+        )
+    ]
+
+    @State private var selectedAction: WellnessAction?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Wellness Actions")
+                .font(.headline)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 12) {
+                    ForEach(actions) { action in
+                        Button {
+                            selectedAction = action
+                        } label: {
+                            Text(action.title)
+                                .font(.subheadline)
+                                .padding(.vertical, 8)
+                                .padding(.horizontal, 12)
+                                .background(Color.accentColor.opacity(0.1))
+                                .cornerRadius(8)
+                        }
+                    }
+                }
+            }
+        }
+        .alert(item: $selectedAction) { action in
+            Alert(
+                title: Text(action.title),
+                message: Text(action.description),
+                dismissButton: .default(Text("Done"))
+            )
+        }
+    }
+}
+
+struct WellnessActionsView_Previews: PreviewProvider {
+    static var previews: some View {
+        WellnessActionsView()
+            .padding()
+            .previewLayout(.sizeThatFits)
+    }
+}
+

--- a/MooDo/Views/Screens/HomeView.swift
+++ b/MooDo/Views/Screens/HomeView.swift
@@ -35,6 +35,9 @@ struct HomeView: View {
                     
                     // Today's Progress (animated counters like web app)
                     TodaysProgressView(tasks: taskManager.tasks, moodEntries: moodManager.moodEntries)
+
+                    // Quick wellness actions
+                    WellnessActionsView()
                 }
                 .padding(.horizontal, 20)
                 .padding(.top, max(screenSize.height * 0.08, 60))


### PR DESCRIPTION
## Summary
- Add WellnessActionsView with breathing, stretch, and gratitude prompts
- Show quick wellness actions on HomeView
- Schedule gentle wellness reminder notifications after long focus tasks

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -project MooDo.xcodeproj -scheme MooDo build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_6896eae85ca4832e9455efbdc17d6d96