### PR TITLE
Fix singular day string in creation date formatter

### DIFF
--- a/MooDo/Utils/DateFormatting.swift
+++ b/MooDo/Utils/DateFormatting.swift
@@ -57,7 +57,8 @@ struct DateFormatting {
         } else {
             let daysAgo = calendar.dateComponents([.day], from: date, to: now).day ?? 0
             if daysAgo <= 7 {
-                return "\(daysAgo) days ago"
+                let unit = daysAgo == 1 ? "day" : "days"
+                return "\(daysAgo) \(unit) ago"
             } else {
                 return shortDateFormatter.string(from: date)
             }


### PR DESCRIPTION
## Summary
- handle singular vs. plural in creation date strings

## Testing
- `swiftc -typecheck MooDo/Utils/DateFormatting.swift`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6896e64e2eec832ea570a231a953051d